### PR TITLE
BUG-card-readme fix: readme typo's

### DIFF
--- a/src/comps/Card/README.md
+++ b/src/comps/Card/README.md
@@ -6,11 +6,11 @@ The Card component can be used as a container to display other content.
 
 **children**
 
-| _type:_ node | _required:_ false | _default:_ null | _description:_ Body content of the Button component. |
+| _type:_ node | _required:_ false | _default:_ null | _description:_ Body content of the Card component. |
 
 **size**
 
-| _type:_ string | _required:_ false | _default:_ 'auto' | _description:_ Size of the Button component. | _values:_ 'auto', 'small', 'medium', 'large'. |
+| _type:_ string | _required:_ false | _default:_ 'auto' | _description:_ Size of the Card component. | _values:_ 'auto', 'small', 'medium', 'large'. |
 
 ## Usage
 


### PR DESCRIPTION
Purpose :octocat:

To fix a typo error in the Card readme file.

Notes 📎

- Fixed type error in README.md